### PR TITLE
Fix UIAlertController presentation issue on iPad

### DIFF
--- a/Dine/Menu/Controllers/AddItemViewController.swift
+++ b/Dine/Menu/Controllers/AddItemViewController.swift
@@ -49,7 +49,11 @@ class AddItemViewController: UIViewController {
         pickerView.dataSource = self
         
         alert.view.addSubview(pickerView)
-        
+        if let popoverController = alert.popoverPresentationController {
+            popoverController.sourceView = self.view // Specify the view from which the popover should originate
+            popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0) // Set the rectangle for the popover
+            popoverController.permittedArrowDirections = [] // Optional: specify allowed arrow directions
+        }
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(title: "Done", style: .default, handler: { _ in
             let selectedIndex = self.pickerView.selectedRow(inComponent: 0)


### PR DESCRIPTION
## Summary

This pull request fixes the issue where a `UIAlertController` of style `UIAlertControllerStyleActionSheet` would cause an error when presented on an iPad due to missing popover presentation information.

## Changes

- Set the `sourceView` and `sourceRect` for the `popoverPresentationController` to ensure the action sheet is displayed correctly on iPad.
- Alternatively, set the `barButtonItem` if presenting from a bar button item.

## Code Example

```swift
// Create the alert controller
let alertController = UIAlertController(title: "Title", message: "Message", preferredStyle: .actionSheet)

// Add an action
let action = UIAlertAction(title: "Action", style: .default) { _ in
    // Handle action
}
alertController.addAction(action)

// Configure popover presentation for iPad
if let popoverController = alertController.popoverPresentationController {
    popoverController.sourceView = self.view // Specify the view from which the popover should originate
    popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0) // Set the rectangle for the popover
    popoverController.permittedArrowDirections = [] // Optional: specify allowed arrow directions
}

// Present the alert controller
self.present(alertController, animated: true, completion: nil)
