### PR TITLE
feat: add tap gesture recognizer to dismiss keyboard on view tap

### DIFF
--- a/Dine/UserAuth/Controllers/LoginViewController.swift
+++ b/Dine/UserAuth/Controllers/LoginViewController.swift
@@ -80,6 +80,15 @@ class LoginViewController: UIViewController {
         setupSignUpLabelGesture()
         view.backgroundColor = .systemBackground
         title = "Login"
+        
+        let tap = UITapGestureRecognizer(target: self, action: #selector(UIInputViewController.dismissKeyboard))
+        //Uncomment the line below if you want the tap not not interfere and cancel other interactions.
+        // tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
     
     @objc private func loginButtonAction(_ sender: UIButton) {

--- a/Dine/UserAuth/Controllers/SignUpViewController.swift
+++ b/Dine/UserAuth/Controllers/SignUpViewController.swift
@@ -78,6 +78,15 @@ class SignUpViewController: UIViewController {
         view.keyboardLayoutGuide.followsUndockedKeyboard = true
         setupSubviews()
         view.backgroundColor = .systemBackground
+        
+        let tap = UITapGestureRecognizer(target: self, action: #selector(UIInputViewController.dismissKeyboard))
+        //Uncomment the line below if you want the tap not not interfere and cancel other interactions.
+        // tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
     
     @objc private func signUpButtonAction(_ sender: UIButton) {


### PR DESCRIPTION
### closes #33 
- Added UITapGestureRecognizer to main view in ViewController
- Implemented dismissKeyboard method to end editing and hide keyboard
- Ensured keyboard is dismissed when tapping outside text input areas
